### PR TITLE
Replace Background with ClipShape

### DIFF
--- a/MiLogo.playground/Sources/MiLogo.swift
+++ b/MiLogo.playground/Sources/MiLogo.swift
@@ -11,7 +11,8 @@ public struct MiLogo: View {
             .font(Font.custom("Babylon Industrial", size: 14))
             .padding(10)
             .frame(width: 40, height: 40)
-            .background(SuperEllipse(n: n).fill(Color.white))
+            .background(Color.white)
+            .clipShape(SuperEllipse(n: n))
     }
 }
 


### PR DESCRIPTION
I would like to discuss about the Shape of the `MiLogo`, I found that `ClipShape` is more understanding than `background`.  Here are my reasons:

- Background tells a story about a view is containing in another view.
- Clip shape tells a story about a view is clipped by a shape.